### PR TITLE
Update code to use app.name property

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ module.exports = function(app, shell) {
   ];
 
   if (process.platform === 'darwin') {
-    const name = app.getName();
+    const { name } = app;
     template.unshift({
       label: name,
       submenu: [


### PR DESCRIPTION
The `app.getName()` API is getting deprecated for the `app.name` property.